### PR TITLE
Change async runtime for build script and bump tokio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,15 +132,16 @@ dependencies = [
 
 [[package]]
 name = "async-std"
-version = "1.6.5"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9fa76751505e8df1c7a77762f60486f60c71bbd9b8557f4da6ad47d083732ed"
+checksum = "8f9f84f1280a2b436a2c77c2582602732b6c2f4321d5494d6e799e6c367859a8"
 dependencies = [
+ "async-channel",
  "async-global-executor",
  "async-io",
  "async-mutex",
  "blocking",
- "crossbeam-utils",
+ "crossbeam-utils 0.8.1",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -151,7 +152,7 @@ dependencies = [
  "memchr",
  "num_cpus",
  "once_cell",
- "pin-project-lite 0.1.11",
+ "pin-project-lite 0.2.0",
  "pin-utils",
  "slab",
  "wasm-bindgen-futures",
@@ -536,7 +537,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b153fe7cbef478c567df0f972e02e6d736db11affe43dfc9c56a9374d1adfb87"
 dependencies = [
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
  "maybe-uninit",
 ]
 
@@ -548,6 +549,17 @@ checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 dependencies = [
  "autocfg",
  "cfg-if 0.1.10",
+ "lazy_static",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
+dependencies = [
+ "autocfg",
+ "cfg-if 1.0.0",
  "lazy_static",
 ]
 
@@ -698,11 +710,11 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed85775dcc68644b5c950ac06a2b23768d3bc9390464151aaf27136998dcf9e"
+checksum = "0c122a393ea57648015bf06fbd3d372378992e86b9ff5a7a497b076a28c79efe"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
  "redox_syscall",
  "winapi",
@@ -774,7 +786,6 @@ checksum = "c70be434c505aee38639abccb918163b63158a4b4bb791b45b7023044bdc3c9c"
 dependencies = [
  "futures-channel",
  "futures-core",
- "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -796,17 +807,6 @@ name = "futures-core"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db8d3b0917ff63a2a96173133c02818fac4a746b0a57569d3baca9ec0e945e08"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ee9ca2f7eb4475772cf39dd1cd06208dce2670ad38f4d9c7262b3e15f127068"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
 
 [[package]]
 name = "futures-io"
@@ -1900,7 +1900,7 @@ dependencies = [
  "base64 0.12.3",
  "blake2b_simd",
  "constant_time_eq",
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
 ]
 
 [[package]]
@@ -2233,14 +2233,15 @@ checksum = "238ce071d267c5710f9d31451efec16c5ee22de34df17cc05e56cbc92e967117"
 
 [[package]]
 name = "tokio"
-version = "0.2.22"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d34ca54d84bf2b5b4d7d31e901a8464f7b60ac145a284fba25ceb801f2ddccd"
+checksum = "099837d3464c16a808060bb3f02263b412f6fafcb5d01c533d309985fbeebe48"
 dependencies = [
  "bytes 0.5.6",
  "fnv",
  "futures-core",
  "pin-project-lite 0.1.11",
+ "slab",
  "tokio-macros",
 ]
 
@@ -2260,9 +2261,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
+checksum = "e44da00bfc73a25f814cd8d7e57a68a5c31b74b3152a0a1d1f590c97ed06265a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2301,7 +2302,7 @@ dependencies = [
  "futures-sink",
  "log",
  "pin-project-lite 0.1.11",
- "tokio 0.2.22",
+ "tokio 0.2.24",
 ]
 
 [[package]]
@@ -2335,7 +2336,7 @@ dependencies = [
  "nom",
  "serde",
  "serde_json",
- "tokio 0.2.22",
+ "tokio 0.2.24",
  "tokio-util 0.3.1",
  "tower-lsp-macros",
  "tower-service",
@@ -2422,10 +2423,10 @@ dependencies = [
 name = "tremor-language-server"
 version = "0.9.2"
 dependencies = [
+ "async-std",
  "bincode",
  "clap",
  "flate2",
- "futures",
  "glob",
  "halfbrown",
  "home",
@@ -2434,7 +2435,7 @@ dependencies = [
  "serde_json",
  "simd-json",
  "tar",
- "tokio 0.2.22",
+ "tokio 0.2.24",
  "tower-lsp",
  "tremor-script",
  "walkdir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,7 @@ walkdir = "2.3"
 # for downloading and extracting tremor-script crate (when we can't read
 # it from the local cargo registry), in order to access the tremor script
 # stdlib documentation
-futures = "0.3.9"
-tokio = "0.2.22"
+async-std = "1.8"
 tar = "0.4"
 flate2 = "1.0"
 reqwest = "0.11"
@@ -40,6 +39,7 @@ clap = "2.33"
 
 halfbrown = "0.1"
 serde_json = "1.0.61"
+# this version of tokio is needed for compatibility with tower-lsp currently
 tokio = { version = "0.2", features = ["io-std", "macros", "sync"] }
 tower-lsp = "0.13"
 

--- a/build.rs
+++ b/build.rs
@@ -16,6 +16,7 @@ use flate2::read::GzDecoder;
 use regex::Regex;
 use std::borrow::Borrow;
 // used instead of halfbrown::Hashmap because bincode can't deserialize that
+use async_std::task;
 use std::collections::HashMap;
 use std::env;
 use std::ffi::OsStr;
@@ -90,11 +91,11 @@ fn get_tremor_script_crate_path(download_dir: &str) -> String {
         Some(path) => path,
         None => {
             println!("Could not find tremor-script src in local cargo registry, so downloading it now...");
-            download_and_extract_crate(
+            task::block_on(download_and_extract_crate(
                 TREMOR_SCRIPT_CRATE_NAME,
                 tremor_script_version,
                 download_dir,
-            )
+            ))
             .unwrap()
         }
     }
@@ -294,8 +295,6 @@ fn get_local_cargo_registry_path_for_crate(
         .map(|pathbuf| pathbuf.display().to_string()))
 }
 
-// run this async function with tokio runtime
-#[tokio::main]
 async fn download_and_extract_crate(
     name: &str,
     version: &str,


### PR DESCRIPTION
This resolves https://github.com/tremor-rs/tremor-language-server/pull/115 partially: eliminates the `tokio` use in the build script in favor of `async-std`, and bumps `tokio` version used in the app from 0.2.22 to 0.2.24.

We can't upgrade to `tokio` 1.0 yet because `tower-lsp` (crate we use for language-server heavy-lifting) currently works only with tokio 0.2. Once the PR https://github.com/ebkalderon/tower-lsp/pull/238 is resolved upstream, we can safely bump tokio too here.