### PR TITLE
Update libssl package to be installable during CI checks

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -41,8 +41,7 @@ jobs:
       - uses: actions/checkout@v1
       - name: Install deps
         run: |
-            sudo apt update
-            sudo apt install -y libssl1.0-dev libssl1.0
+            sudo apt-get -qy update && sudo apt-get install -y libssl-dev libssl1.1
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,8 +9,7 @@ jobs:
       - uses: actions/checkout@v1
       - name: Install deps [Linux]
         run: |
-            sudo apt update
-            sudo apt install -y libssl1.0-dev libssl1.0
+            sudo apt-get -qy update && sudo apt-get install -y libssl-dev libssl1.1
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -23,8 +22,7 @@ jobs:
       - uses: actions/checkout@v1
       - name: Install deps
         run: |
-            sudo apt update
-            sudo apt install -y libssl1.0-dev libssl1.0
+            sudo apt-get -qy update && sudo apt-get install -y libssl-dev libssl1.1
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable


### PR DESCRIPTION
Should fix CI issues in https://github.com/tremor-rs/tremor-language-server/pull/127