### PR TITLE
Exclude tremor-www-docs from crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,12 @@ edition = "2018"
 license = "Apache-2.0"
 name = "tremor-language-server"
 version = "0.11.3"
+exclude = [
+    "tremor-www-docs", 
+    "!tremor-www-docs/docs/tremor-query", 
+    "tremor-www-docs/docs/tremor-query/grammar",
+    "!tremor-www-docs/docs/tremor-script",
+    "tremor-www-docs/docs/tremor-script/grammar"]
 
 [build-dependencies]
 bincode = "1.3"
@@ -45,3 +51,4 @@ tower-lsp = "0.13"
 
 # tremor deps
 tremor-script = "0.11.3"
+


### PR DESCRIPTION
It was blowing up our crate size to roughly 30MB, while all we need is the tremor-query and tremor-script sections.