### PR TITLE
removed bump from cargo set-version

### DIFF
--- a/.github/workflows/draft-new-release.yaml
+++ b/.github/workflows/draft-new-release.yaml
@@ -27,7 +27,7 @@ jobs:
         run: |
           OLD_VERSION=$(cargo pkgid | cut -d# -f2 | cut -d: -f2)
           echo "OLD=$OLD_VERSION" >> $GITHUB_ENV
-          cargo set-version --workspace --bump ${{github.event.inputs.version}}
+          cargo set-version ${{github.event.inputs.version}}
           NEW_VERSION=$(cargo pkgid | cut -d# -f2 | cut -d: -f2)
           echo "NEW=$NEW_VERSION" >> $GITHUB_ENV   
       - name: Create release branch


### PR DESCRIPTION
Signed-off-by: PrimalPimmy <Prashant20.pm@gmail.com>

This is because we have already set which version we want when drafting release in `tremor-runtime`. So I don't see an advantage of using it here too. Directly putting version works, since we already choose from [major minor rc...] on `tremor-runtime` , and then that version gets transferred here.